### PR TITLE
DockerfileでHugo_extendedのバージョンを指定してインストールさせる

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+    "name": "The Altive Handbook",
+    "build": {
+        "dockerfile": "Dockerfile"
+    }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:latest
+
+# Hugo Extendedのバージョンを指定する。
+ARG HUGO_VERSION=0.121.1
+
+# SASSを使用しているため、 hugo_extended をダウンロードして使用する必要がある。
+RUN wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+    && sudo dpkg --install --skip-same-version hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+    && rm hugo_extended_${HUGO_VERSION}_linux-amd64.deb


### PR DESCRIPTION
## 🙌 やったこと

<!-- このプルリクエストでやったことをリストアップする -->
<!-- 関連するIssueがあれば示す e.g. - closes #999 -->

- リモートで環境構築してくれる、GitHub Codespacesをこのリポジトリで使ってみたのですが、初期インストールされているHugoは拡張版ではないためSCSSに対応しておらず、 `hugo` コマンドがエラーで使えませんでした
- DockerfileでHugo_extendedのバージョンを指定してインストールさせると解決するかも？ということで追加してみました！

## ✍️ やらないこと

<!-- このプルリクエストで明示的にやらないことがあればリストアップする -->

- 

## 📝 その他

<!-- レビュワーへの参考情報（懸念点や注意点等があれば記載する） -->

### 参考リンク

- https://chat.openai.com/share/8f0ab428-ec5b-4365-bf6e-b3efa8e7a1c2
- https://gohugo.io/troubleshooting/faq/#an-error-message-indicates-that-a-feature-is-not-available-why
- https://qiita.com/noritakaIzumi/items/39f0bfc554be5125ad72
